### PR TITLE
v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What does this app do?
 
-This app checks whether variants detected at a set of PRS positions are sufficiently covered (as specified by the depth input) and optionally whether they overlap any copy number variants (CNV), which is noted in text output files. This app can optionally convert the genotypes of low coverage and CNV intersecting variants to 0/0. Furthermore, the app outputs a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
+Read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted. Optionally, variants with sub-threshold read depth may have their genotype converted to 0/0 (default is `true`).  If required, it also checks the CNV segments file using `bcftools isec` to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. Moreover, PRS variants which occur in CNVs can optionally have their genotype converted to 0/0 (default is `true`). Lastly, PRS variants which were not able to be called (i.e. that have a GT = ./.) can optionally have their genotype be converted to 0/0 (default is `true`). Furthermore, the app outputs a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
 
 ## What inputs are required for this app to run?
 
@@ -15,14 +15,13 @@ This app checks whether variants detected at a set of PRS positions are sufficie
 
 
 ## How does this app work?
-
-Read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted. Optionally, variants with sub-threshold read depth may have their genotype converted to 0/0 (default is `true`).  If required, it also checks the CNV segments file using `bcftools isec` to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. Moreover, PRS variants which occur in CNVs can optionally have their genotype converted to 0/0 (default is `true`). Lastly, PRS variants which were not able to be called (i.e. that have a GT = ./.) can optionally have their genotype be converted to 0/0 (default is `true`).
+The app first identifies variants in the sample VCF with sub-threshold depth values using `bcftools filter` and the specified depth threshold, as provided via the `depth` input. If such variants are found, a .txt file containing a description of the variants (CHROM, POS, REF, ALT, DP, GT) is outputted. If requested, the app will then convert the GT values for these variants to 0/0 using a custom bash function `convert_gt` (see eggd_CANRISK_vcf.sh for more details). Next, if a segments VCF is provided via the `segments_vcf` input, it checks for any CNVs that have been called via `bcftools filter` and then for any overlaps of the CNVs with PRS variants in the sample VCF using `bcftools isec`. If requested, it converts the GTs of CNV overlapping variants to 0/0 via the `convert_gt` function. Additionally, a .txt file is outputted describing these variants.
 
 ## What does this app output?
 
 - a filtered VCF compatible with CANRISK
-- a text file listing excluded variants that are covered at less than input depth (default 20x)
-- a text file listing PRS positions that are affected by an overlapping CNV
+- a text file listing variants that are covered at less than input depth (default 20x), if no such variants exist then no text file is outputted.
+- a text file listing PRS variants that are affected by an overlapping CNV, if no such variants exist then no text file is outputted.
 
 ## What limitations does this app have?
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,30 @@
 
 ## What does this app do?
 
-This app checks whether variants detected at a set of PRS positions are sufficiently covered and optionally whether they overlap any copy number variants,
-which is noted in text output files. Furthermore, the app generates a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
+This app checks whether variants detected at a set of PRS positions are sufficiently covered (as specified by the depth input) and optionally whether they overlap any copy number variants (CNV), which is noted in text output files. This app can optionally convert the genotypes of low coverage and CNV intersecting variants to 0/0. Furthermore, the app outputs a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
 
 ## What inputs are required for this app to run?
 
 - sample VCF from Sentieon Haplotyper (called against PRS variants)
 - segments VCF from GATK gCNV (optional)
 - a read depth threshold can be set (optional, defaults to 20)
+- boolean whether to convert the genotype of PRS variants which intersect with CNVs to 0/0 (optional, default true)
+- boolean whether to convert the genotype of PRS variants with low coverage (as specified by the depth threshold input) to 0/0 (optional, default true)
+- boolean whether to convert the genotype of PRS variants that were not called (i.e. GT = ./.) to 0/0 (optional, default true)
+
 
 ## How does this app work?
 
-PRS variants are filtered based on read depth (optional input) and variants below the threshold are reported in a text output file.
-If required, it also checks the CNV segments file using bedtools intersect, to see if any PRS variants are in CNVs.
-Optionally, PRS variants are excluded from the output VCF (default behaviour). Otherwise all variants are retained in the output VCF.
-
+Read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted. Optionally, variants with sub-threshold read depth may have their genotype converted to 0/0 (default is `true`).  If required, it also checks the CNV segments file using `bcftools isec` to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. Moreover, PRS variants which occur in CNVs can optionally have their genotype converted to 0/0 (default is `true`). Lastly, PRS variants which were not able to be called (i.e. that have a GT = ./.) can optionally have their genotype be converted to 0/0 (default is `true`).
 
 ## What does this app output?
 
-- a filtered VCF compatible with CANRISK, excluding variants that do not reach the coverage threshold specified (by default)
+- a filtered VCF compatible with CANRISK
 - a text file listing excluded variants that are covered at less than input depth (default 20x)
 - a text file listing PRS positions that are affected by an overlapping CNV
 
 ## What limitations does this app have?
 
-This assumes the provided VCF is already limited to the PRS variants list, and contains a genotype for all those variants.
+This assumes the provided VCF is already limited to the PRS variants list.
 
 ## This app was created by East GLH

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## What does this app do?
 
-Read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted. Optionally, variants with sub-threshold read depth may have their genotype converted to 0/0 (default is `true`).  If required, it also checks the CNV segments file using `bcftools isec` to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. Moreover, PRS variants which occur in CNVs can optionally have their genotype converted to 0/0 (default is `true`). Lastly, PRS variants which were not able to be called (i.e. that have a GT = ./.) can optionally have their genotype be converted to 0/0 (default is `true`). Furthermore, the app outputs a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
+First, it checks for PRS variants which were not able to be called (i.e. that have a GT = ./.) and records these variants in a .txt file. If no variants are found no .txt is outputted. If requested via the `convert_gt_no_call` input (default is `true`), their genotypes are converted to 0/0.
+
+Next, read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted. Optionally, these variants with sub-threshold read depth may have their genotype converted to 0/0, as specified by the `convert_gt_low_dp` input (default is `true`).
+
+After this, it checks the CNV segments file (if provided) to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. PRS variants which occur in CNVs can optionally have their genotype converted to 0/0 as specified by the `convert_gt_cnv` input (default is `true`).
+
+Lastly, the app outputs a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
 
 ## What inputs are required for this app to run?
 
@@ -15,13 +21,18 @@ Read depths of PRS variants are inspected and variants below the threshold are r
 
 
 ## How does this app work?
-The app first identifies variants in the sample VCF with sub-threshold depth values using `bcftools filter` and the specified depth threshold, as provided via the `depth` input. If such variants are found, a .txt file containing a description of the variants (CHROM, POS, REF, ALT, DP, GT) is outputted. If requested, the app will then convert the GT values for these variants to 0/0 using a custom bash function `convert_gt` (see eggd_CANRISK_vcf.sh for more details). Next, if a segments VCF is provided via the `segments_vcf` input, it checks for any CNVs that have been called via `bcftools filter` and then for any overlaps of the CNVs with PRS variants in the sample VCF using `bcftools isec`. If requested, it converts the GTs of CNV overlapping variants to 0/0 via the `convert_gt` function. Additionally, a .txt file is outputted describing these variants.
+The app first identifies variants which were unable to be called via `bcftools filter` using the condition `FORMAT/GT=="./."`. If such variants are found, a .txt file containing a description of the variants (CHROM, POS, REF, ALT, DP, GT) is outputted using `bcftools isec` and `bcftools query`. If requested, the genotypes of these variants in the sample VCF are converted to 0/0 using a custom bash function `convert_gt` (see eggd_CANRISK_vcf.sh for more details).
+
+Next, the script finds variants in the sample VCF with sub-threshold depth values using `bcftools filter` and the specified depth threshold given via the `depth` input. If requested, the app will then convert the GT values for these variants to 0/0 using the `convert_gt` function and a .txt file describing any such variants is outputted (as described above).
+
+If a segments VCF is provided via the `segments_vcf` input, it checks for any CNVs that have been called via `bcftools filter` and then for any overlaps of the CNVs with PRS variants in the sample VCF using `bcftools isec`. If requested, it converts the GTs of CNV overlapping variants to 0/0 via the `convert_gt` function and a .txt file is outputted describing these variants (as described above).
 
 ## What does this app output?
 
 - a filtered VCF compatible with CANRISK
 - a text file listing variants that are covered at less than input depth (default 20x), if no such variants exist then no text file is outputted.
 - a text file listing PRS variants that are affected by an overlapping CNV, if no such variants exist then no text file is outputted.
+- a text file listing PRS variants that were not able to be called (i.e. their GT = ./.), if no such variants exist then no text file is outputted.
 
 ## What limitations does this app have?
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,10 @@
   "title": "eggd_canrisk_vcf",
   "summary": "App to convert VCF output from sentieon Haplotyper for PRS variants to a format compatible with the CANRISK tool",
   "version": "1.1.0",
-  "whatsNew": "* v1.0.0 Initial release of the app; v1.1.0 TBC!!!!!!!!!!",
+  "whatsNew": {
+    "v1.0.0": "Initial release of the app",
+    "v1.1.0": "Optional conversion of uncertain genotypes to 0/0, GT info added to check files and no longer output them if empty, removed exclude variants input"
+  },
   "dxapi": "1.0.0",
   "authorizedUsers": [
       "org-emee_1"

--- a/dxapp.json
+++ b/dxapp.json
@@ -89,6 +89,14 @@
       "patterns": [
         "*coverage_check.txt"
       ]
+    },
+    {
+      "name": "uncalled_check",
+      "class": "file",
+      "optional": true,
+      "patterns": [
+        "*uncalled_variants_check.txt"
+      ]
     }
   ],
   "runSpec": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -2,8 +2,8 @@
   "name": "eggd_canrisk_vcf",
   "title": "eggd_canrisk_vcf",
   "summary": "App to convert VCF output from sentieon Haplotyper for PRS variants to a format compatible with the CANRISK tool",
-  "version": "1.0.0",
-  "whatsNew": "* v1.0.0 Initial release of the app;",
+  "version": "1.1.0",
+  "whatsNew": "* v1.0.0 Initial release of the app; v1.1.0 TBC!!!!!!!!!!",
   "dxapi": "1.0.0",
   "authorizedUsers": [
       "org-emee_1"
@@ -39,9 +39,25 @@
       "default": "20"
     },
     {
-      "name": "exclude",
-      "label": "Exclude variants covered below minimum depth threshold",
-      "help": "whether low covered variants should be excluded from output VCF",
+      "name": "convert_gt_cnv",
+      "label": "Convert the genotypes of variants within CNVs to 0/0",
+      "help": "whether the genotpyes of variants should be converted to 0/0 if CNV has been called in that region",
+      "class": "boolean",
+      "optional": true,
+      "default": true
+    },
+    {
+      "name": "convert_gt_low_dp",
+      "label": "Convert the genotypes of low depth variants to 0/0",
+      "help": "whether the genotpyes of low depth (specified by the minimum depth input) variants are converted to 0/0. Cannot =true if exclude=true",
+      "class": "boolean",
+      "optional": true,
+      "default": true
+    },
+    {
+      "name": "convert_gt_no_call",
+      "label": "Convert ./. genotypes to 0/0 ",
+      "help": "whether ./. genotpyes are converted to 0/0",
       "class": "boolean",
       "optional": true,
       "default": true
@@ -58,6 +74,7 @@
     {
       "name": "cnv_check",
       "class": "file",
+      "optional": true,
       "patterns": [
         "*cnv_check.txt"
       ]
@@ -65,6 +82,7 @@
     {
       "name": "coverage_check",
       "class": "file",
+      "optional": true,
       "patterns": [
         "*coverage_check.txt"
       ]
@@ -80,7 +98,7 @@
     "file": "src/eggd_CANRISK_vcf.sh",
     "distribution": "Ubuntu",
     "release": "20.04",
-    "version": "0", 
+    "version": "0",
     "assetDepends": [
       {
         "name": "bedtools",

--- a/dxapp.json
+++ b/dxapp.json
@@ -52,7 +52,7 @@
     {
       "name": "convert_gt_low_dp",
       "label": "Convert the genotypes of low depth variants to 0/0",
-      "help": "whether the genotpyes of low depth (specified by the minimum depth input) variants are converted to 0/0. Cannot =true if exclude=true",
+      "help": "whether the genotpyes of low depth (specified by the minimum depth input) variants are converted to 0/0.",
       "class": "boolean",
       "optional": true,
       "default": true

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -3,42 +3,51 @@
 set -exo pipefail
 
 convert_gt () {
-    # Convert the genotype for variants given in the intersect tsv to 0/0.
+    # Convert the genotype for variants in the given regions file to 0/0.
     original_vcf=$1
-    intersect_tsv=$2
-    output_name=$3
-    regions_file=$4
+    regions_file=$2
+
+    # create intersect vcf using the provided region and vcf files
+    bcftools isec "$original_vcf" -T "$regions_file" -w1 | \
+        bcftools view -H -o intersect.tsv
 
     # make vcf containing non-selected variants, the ^ causes everything which
     # does not intersect the regions file to be used
     bcftools isec "$original_vcf" -T ^"$regions_file" -w1 -o intersect_removed.vcf
 
     # convert selected variant's genotypes to 0/0
-    paste <(cut -f1-9 "$intersect_tsv") \
-        <(cut -f10 "$intersect_tsv" | sed 's/^[^:]*/0\/0/') \
-        <(cut -f11- "$intersect_tsv") > converted_intersect.tsv
+    paste <(cut -f1-9 intersect.tsv) \
+        <(cut -f10 intersect.tsv | sed 's/^[^:]*/0\/0/') \
+        <(cut -f11- intersect.tsv) > converted_intersect.tsv
 
     # add the converted variant entries to the non-selected variants vcf and sort
-    cat intersect_removed.vcf converted_intersect.tsv | bcftools sort -o "$output_name"
-    tabix -f "$output_name"
+    # intermediate "to_be_checked.vcf.gz" file created so as to not overwrite the original
+    # vcf file until checks have been passed
+    cat intersect_removed.vcf converted_intersect.tsv | bcftools sort -o to_be_checked.vcf.gz
+    tabix -f to_be_checked.vcf.gz
 
     # check that all other columns have remained unmodified
     if ! cmp -s <(bcftools view "$original_vcf" -H | cut -f1-9,11-) \
-        <(bcftools view "$output_name" -H | cut -f1-9,11-); then
+        <(bcftools view to_be_checked.vcf.gz -H | cut -f1-9,11-); then
             echo "ERROR: conversion of GT values affected integrity of VCF"
             exit 1
     fi
 
     # check that all GTs have been converted
-    gt=$(bcftools isec "$output_name" -T "$regions_file" -w1 | \
+    gt=$(bcftools isec to_be_checked.vcf.gz -T "$regions_file" -w1 | \
         bcftools query -f '[%GT\n]' | sort | uniq)
     if [[ "$gt" != "0/0" ]]; then
         echo "ERROR: failed to convert GT values"
         exit 1
     fi
 
-    # clean up non-output files
-    rm intersect_removed.vcf converted_intersect.tsv
+    # now that output file has been checked overwrite/update original file and
+    # re-index original vcf
+    mv to_be_checked.vcf.gz "$original_vcf"
+    tabix -f "$original_vcf"
+
+    # clean up intermediate files
+    rm intersect.tsv intersect_removed.vcf converted_intersect.tsv to_be_checked.vcf.gz.tbi
 }
 
 main() {
@@ -58,6 +67,27 @@ main() {
     sample_name=$(basename "$sample_vcf_path" | awk -F '_' '{ print $1 }')
     tabix -f "$sample_vcf_path"
 
+    mark-section "Checking for uncalled PRS variants"
+    bcftools filter -i 'FORMAT/GT=="./."' "$sample_vcf_path" | \
+        bcftools query -f '%CHROM\t%POS\n' > uncalled_coords.tsv
+
+    if [ -s uncalled_coords.tsv ]; then
+        mark-section "Writing uncalled variant check file"
+        echo "The following PRS variants were not called in this sample:" > "$sample_name"_uncalled_variants_check.txt
+        echo -e "\n#CHROM\tPOS\tREF\tALT\tGT" >> "$sample_name"_uncalled_variants_check.txt
+        bcftools isec "$sample_vcf_path" -T uncalled_coords.tsv -w1 | \
+                bcftools query -f '[%CHROM\t%POS\t%REF\t%ALT\t%GT\n]' >> "$sample_name"_uncalled_variants_check.txt
+
+        if $convert_gt_no_call; then
+            mark-section "Converting genotype of uncalled PRS variants to 0/0"
+            convert_gt "$sample_vcf_path" uncalled_coords.tsv
+        else
+            echo "Genotypes of uncalled PRS variants were not converted to 0/0"
+        fi
+    else
+        echo "No uncalled variants found in the sample VCF"
+    fi
+
     mark-section "Checking for low coverage"
     # identify variants with low coverage (below depth threshold input)
     filter="FORMAT/DP<$depth"
@@ -65,9 +95,6 @@ main() {
         bcftools query -f '%CHROM\t%POS\n' > low_dp_coords.tsv
 
     if [ -s low_dp_coords.tsv ]; then
-
-        bcftools isec "$sample_vcf_path" -T low_dp_coords.tsv -w1 | \
-        bcftools view -H -o PRS_intersect_low_dp.tsv
 
         mark-section "Writing coverage check file"
         # write list of affected PRS variants to output file
@@ -80,7 +107,7 @@ main() {
 
         if $convert_gt_low_dp; then
             mark-section "Converting low coverage PRS variant genotypes to 0/0"
-            convert_gt  "$sample_vcf_path" "PRS_intersect_low_dp.tsv" "$sample_vcf_path" low_dp_coords.tsv
+            convert_gt "$sample_vcf_path" low_dp_coords.tsv
         else
             echo "Genotypes of low coverage PRS variants were not converted to 0/0"
         fi
@@ -106,9 +133,7 @@ main() {
 
         if [ -s CNV_coords.bed ]; then
             mark-section "Writing CNV check file"
-            # Find variants in sample vcf which occur in regions where a CNV has been called
-            bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | \
-                bcftools view -H -o PRS_intersect_CNV.tsv
+
             # write list of affected PRS variants to output file
             echo "The following PRS variants are located within a CNV call in this sample:" > "$sample_name"_cnv_check.txt
             echo -e "\n#CHROM\tPOS\tREF\tALT\tGT" >> "$sample_name"_cnv_check.txt
@@ -121,7 +146,7 @@ main() {
 
             if $convert_gt_cnv; then
                 mark-section "Converting genotype of CNV intersected PRS variants to 0/0"
-                convert_gt "$sample_vcf_path" "PRS_intersect_CNV.tsv" "$sample_vcf_path" "CNV_coords.bed"
+                convert_gt "$sample_vcf_path" "CNV_coords.bed"
             else
                 echo "Genotypes of CNV intersecting PRS variants were not converted to 0/0"
             fi
@@ -130,25 +155,6 @@ main() {
         fi
     else
         echo "No segment VCF provided, therefore no CNV checking was performed for this sample."
-    fi
-
-    mark-section "Checking for uncalled PRS variants"
-    bcftools filter -i 'FORMAT/GT=="./."' "$sample_vcf_path" | \
-        bcftools query -f '%CHROM\t%POS\n' > uncalled_coords.tsv
-
-    if [ -s uncalled_coords.tsv ]; then
-        if $convert_gt_no_call; then
-            mark-section "Converting genotype of uncalled PRS variants to 0/0"
-            bcftools filter -e 'FORMAT/GT=="./."' "$segments_vcf_path" | \
-                bcftools view -H -o PRS_intersect_uncalled.tsv
-
-            convert_gt "$sample_vcf_path" PRS_intersect_uncalled.tsv "$sample_vcf_path" uncalled_coords.tsv
-
-        else
-            echo "Genotypes of uncalled PRS variants were not converted to 0/0"
-        fi
-    else
-        echo "No uncalled variants found in the sample VCF"
     fi
 
     gunzip -c "$sample_vcf_path" > "$sample_name"_canrisk_PRS.vcf
@@ -163,6 +169,11 @@ main() {
     # upload files
     canrisk_VCF=$(dx upload "$sample_name"_canrisk_PRS.vcf --brief)
     dx-jobutil-add-output canrisk_PRS "$canrisk_VCF" --class=file
+
+    if [ -s "$sample_name"_uncalled_variants_check.txt ]; then
+        uncalled_check=$(dx upload "$sample_name"_uncalled_variants_check.txt --brief)
+        dx-jobutil-add-output uncalled_check "$uncalled_check" --class=file
+    fi
 
     if [ -s "$sample_name"_coverage_check.txt ]; then
         coverage_check=$(dx upload "$sample_name"_coverage_check.txt --brief)

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -2,6 +2,44 @@
 
 set -exo pipefail
 
+convert_gt () {
+    # Convert the genotype for variants given in the intersect tsv to 0/0.
+    original_vcf=$1
+    intersect_tsv=$2
+    output_name=$3
+    regions_file=$4
+
+    # make vcf containing non-selected variants
+    bcftools isec "$original_vcf" -T ^"$regions_file" -w1 -o intersect_removed.vcf
+
+    # convert selected variant's genotypes to 0/0
+    paste <(cut -f1-9 "$intersect_tsv") \
+        <(cut -f10 "$intersect_tsv" | sed 's/^[^:]*/0\/0/') \
+        <(cut -f11- "$intersect_tsv") > converted_intersect.tsv
+
+    # add the converted variant entries to the non-selected variants vcf and sort
+    cat intersect_removed.vcf converted_intersect.tsv | bcftools sort -o "$output_name"
+    tabix -f "$output_name"
+
+    # check that all other columns have remained unmodified
+    if ! cmp -s <(bcftools view "$original_vcf" -H | cut -f1-9,11-) \
+        <(bcftools view "$output_name" -H | cut -f1-9,11-); then
+            echo "ERROR: conversion of GT values affected integrity of VCF"
+            exit 1
+    fi
+
+    # check that all GTs have been converted
+    gt=$(bcftools isec "$output_name" -T "$regions_file" -w1 | \
+        bcftools query -f '[%GT\n]' | sort | uniq)
+    if [[ "$gt" != "0/0" ]]; then
+        echo "ERROR: failed to convert GT values"
+        exit 1
+    fi
+
+    # clean up non-output files
+    rm intersect_removed.vcf converted_intersect.tsv
+}
+
 main() {
 
     ### INPUTS
@@ -9,80 +47,116 @@ main() {
     dx-download-all-inputs --parallel
 
     ### PROCESS
+    # check for input conflicts
+    if [[ -z "$segments_vcf_path" ]] && $convert_gt_cnv; then
+        echo "ERROR: no segments file was provided via segments_vcf but convert_gt_cnv was set to true"
+        exit 1
+    fi
 
     # get full sample name
-    sample_name=$(basename $sample_vcf_path | awk -F '_' '{ print $1 }')
+    sample_name=$(basename "$sample_vcf_path" | awk -F '_' '{ print $1 }')
+    tabix -f "$sample_vcf_path"
 
-    ## 1. check CNV overlap:
-    # if segments file input is provided, check if any PRS variants are in a CNV
-    # by converting CNV coordinates to a bed file
-    if [ $segments_vcf_path ]; then
-        mark-section "Checking for overlapping CNVs"
-        # check CNV VCF filename matches sample from input VCF
-        segment_sample_name=$(basename $segments_vcf_path | awk -F '_' '{ print $1 }')
-        if ! [ $sample_name == $segment_sample_name ]; then
+    mark-section "Checking for low coverage"
+    # identify variants with low coverage (below depth threshold input)
+    filter="FORMAT/DP<$depth"
+    bcftools filter -i "$filter" "$sample_vcf_path" | \
+        bcftools query -f '%CHROM\t%POS\n' > low_dp_coords.tsv
+
+    if [ -s low_dp_coords.tsv ]; then
+
+        bcftools isec "$sample_vcf_path" -T low_dp_coords.tsv -w1 | \
+        bcftools view -H -o PRS_intersect_low_dp.tsv
+
+        mark-section "Writing coverage check file"
+        # write list of affected PRS variants to output file
+        bcftools filter -i "$filter" "$sample_vcf_path" > low_cov_PRS.vcf
+        echo "The following PRS variants are not covered to $depth x read depth:" > "$sample_name"_coverage_check.txt
+        echo -e "\n#CHROM\tPOS\tREF\tALT\tDP\tGT" >> "$sample_name"_coverage_check.txt
+        # write relevant info about affected variants from filtered VCF
+        bcftools query -f '[%CHROM\t%POS\t%REF\t%ALT\t%DP\t%GT\n]' low_cov_PRS.vcf >> "$sample_name"_coverage_check.txt
+        echo -e "\nEnd of file" >> "$sample_name"_coverage_check.txt
+
+        if $convert_gt_low_dp; then
+            mark-section "Converting low coverage PRS variant genotypes to 0/0"
+            convert_gt  "$sample_vcf_path" "PRS_intersect_low_dp.tsv" "$sample_vcf_path" low_dp_coords.tsv
+        else
+            echo "Genotypes of low coverage PRS variants were not converted to 0/0"
+        fi
+    else
+        echo "No low coverage variants present in sample VCF"
+    fi
+
+    if [[ -n "$segments_vcf_path" ]]; then
+        mark-section "Checking CNV segments filename matches sample from input VCF"
+        segment_sample_name=$(basename "$segments_vcf_path" | awk -F '_' '{ print $1 }')
+        if ! [ "$sample_name" == "$segment_sample_name" ]; then
             echo "ERROR: sample names do not match between sample VCF and segment VCF"
             exit 1
         fi
 
+        mark-section "Checking for overlapping CNVs"
+        # if segments file input is provided, check if any PRS variants are in a CNV
+        # by converting CNV coordinates to a bed file
         # identify CNVs from the segments VCF (bcftools filter)
         # parse their coordinates to a bed file (bcftools query)
-        bcftools filter -e 'FORMAT/GT=="0/0"' $segments_vcf_path | \
+        bcftools filter -e 'FORMAT/GT=="0/0"' "$segments_vcf_path" | \
             bcftools query -f '%CHROM\t%POS\t%INFO/END\n' > CNV_coords.bed
 
-        # check whether any of the CNVs cover any PRS variants of interest
-        bedtools intersect -a $sample_vcf_path -b CNV_coords.bed > PRS_intersect_CNV.tsv
+        if [ -s CNV_coords.bed ]; then
+            mark-section "Writing CNV check file"
+            # Find variants in sample vcf which occur in regions where a CNV has been called
+            bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | \
+                bcftools view -H -o PRS_intersect_CNV.tsv
+            # write list of affected PRS variants to output file
+            echo "The following PRS variants are located within a CNV call in this sample:" > "$sample_name"_cnv_check.txt
+            echo -e "\n#CHROM\tPOS\tREF\tALT\tGT" >> "$sample_name"_cnv_check.txt
 
-        # write list of affected PRS variants to output file
-        echo "The following PRS variants are located within a CNV call in this sample:" > "$sample_name"_cnv_check.txt
-        echo -e "\n#CHROM\tPOS\tREF\tALT" >> "$sample_name"_cnv_check.txt
-        # write relevant info about affected variants
-        cut -f 1,2,4,5 PRS_intersect_CNV.tsv >> "$sample_name"_cnv_check.txt
-        echo -e "\nEnd of file" >> "$sample_name"_cnv_check.txt
+            # write relevant info about affected variants
+            bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | \
+                bcftools query -f '[%CHROM\t%POS\t%REF\t%ALT\t%GT\n]' >> "$sample_name"_cnv_check.txt
+
+            echo -e "\nEnd of file" >> "$sample_name"_cnv_check.txt
+
+            if $convert_gt_cnv; then
+                mark-section "Converting genotype of CNV intersected PRS variants to 0/0"
+                convert_gt "$sample_vcf_path" "PRS_intersect_CNV.tsv" "$sample_vcf_path" "CNV_coords.bed"
+            else
+                echo "Genotypes of CNV intersecting PRS variants were not converted to 0/0"
+            fi
+        else
+            echo "No CNVs called in PRS regions"
+        fi
     else
-        echo "CNV checking was not performed for this sample." > "$sample_name"_cnv_check.txt
+        echo "No segment provided, therefore no CNV checking was performed for this sample."
     fi
 
-    ## 2. check coverage:
-    mark-section "Checking for low coverage"
-    # identify variants with low coverage (below depth threshold input)
-    filter="FORMAT/DP<$depth"
-    bcftools filter -i $filter $sample_vcf_path > low_cov_PRS.vcf
+    gunzip -c "$sample_vcf_path" > "$sample_name"_canrisk_PRS.vcf
 
-    # write list of affected PRS variants to output file
-    echo "The following PRS variants are not covered to $depth x read depth:" > "$sample_name"_coverage_check.txt
-    echo -e "\n#CHROM\tPOS\tREF\tALT\tDP" >> "$sample_name"_coverage_check.txt
-    # write relevant info about affected variants from filtered VCF
-    bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\t[%DP]\n' low_cov_PRS.vcf  >> "$sample_name"_coverage_check.txt
-    echo -e "\nEnd of file" >> "$sample_name"_coverage_check.txt
+    if $convert_gt_no_call; then
+        mark-section "Converting genotype of uncalled PRS variants to 0/0"
+        sed -i 's/\.\/\./0\/0/g' "$sample_name"_canrisk_PRS.vcf
+    fi
 
-    ## 3. filter VCF file:
-    case $exclude in
-    (true)
-        mark-section "Filtering PRS VCF by coverage"
-        # exclude low covered PRS variants
-        bcftools filter -e $filter $sample_vcf_path > "$sample_name"_canrisk_PRS.vcf
-        echo "Retained $(grep -v ^# "$sample_name"_canrisk_PRS.vcf | wc -l) variants after depth filtering"
-        ;;
-    (false)
-        mark-section "Renaming unfiltered PRS VCF"
-        gunzip -c $sample_vcf_path > "$sample_name"_canrisk_PRS.vcf
-        echo "Retained all variants"
-        ;;
-    esac
+    sed -i 's/4\t84370124\trs10718573\tTA\tT/4\t84370124\trs10718573\tTAA\tTA/' "$sample_name"_canrisk_PRS.vcf
+    sed -i 's/22\t38583315\trs138179519\tA\tAAAAG/22\t38583315\trs138179519\tAAAAG\tAAAAGAAAG/' "$sample_name"_canrisk_PRS.vcf
 
     ### OUTPUTS
     mark-section "Uploading output files"
     # upload files
     canrisk_VCF=$(dx upload "$sample_name"_canrisk_PRS.vcf --brief)
-    cnv_check=$(dx upload "$sample_name"_cnv_check.txt --brief)
-    coverage_check=$(dx upload "$sample_name"_coverage_check.txt --brief)
-
     dx-jobutil-add-output canrisk_PRS "$canrisk_VCF" --class=file
-    dx-jobutil-add-output cnv_check "$cnv_check" --class=file
-    dx-jobutil-add-output coverage_check "$coverage_check" --class=file
+
+    if [ -s "$sample_name"_coverage_check.txt ]; then
+        coverage_check=$(dx upload "$sample_name"_coverage_check.txt --brief)
+        dx-jobutil-add-output coverage_check "$coverage_check" --class=file
+    fi
+
+    if [ -s "$sample_name"_cnv_check.txt ]; then
+        cnv_check=$(dx upload "$sample_name"_cnv_check.txt --brief)
+        dx-jobutil-add-output cnv_check "$cnv_check" --class=file
+    fi
 
 	dx-upload-all-outputs --parallel
 	mark-success
-
 }

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -133,7 +133,7 @@ main() {
     fi
 
     mark-section "Checking for uncalled PRS variants"
-    bcftools filter -e 'FORMAT/GT=="./."' "$sample_vcf_path" | \
+    bcftools filter -i 'FORMAT/GT=="./."' "$sample_vcf_path" | \
         bcftools query -f '%CHROM\t%POS\n' > uncalled_coords.tsv
 
     if [ -s uncalled_coords.tsv ]; then


### PR DESCRIPTION
- Implement function to convert genotypes of uncertain genotypes to ref/ref (0/0), which can be applied optionally
    - #11
- Incorporate into the script conversion of variant representation to non-parsimonious form and conversion of uncalled variants to 0/0, which are currently done manually (see [Canrisk manual v3](https://cuhbioinformatics.atlassian.net/wiki/spaces/DV/pages/3073802241/Canrisk+Manual+v3)) 
    - #10
    - #14
 - Display genotype of PRS variants which failed depth and CNV overlap checks in their respective check files
    - #12 
    - #13  
 - Fix #15 
 - No longer output empty check files if no variants are found which fail the checks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_CANRISK_vcf/16)
<!-- Reviewable:end -->
