### PR TITLE
Fix gt x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ## What does this app do?
 
-First, it checks for PRS variants which were not able to be called (i.e. that have a GT = ./.) and records these variants in a .txt file. If no variants are found no .txt is outputted. If requested via the `convert_gt_no_call` input (default is `true`), their genotypes are converted to 0/0.
+First, it checks for PRS variants which were not able to be called (i.e. that have a GT = ./.) and records these variants in a .txt file. If no variants are found no .txt is outputted.
 
-Next, read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted. Optionally, these variants with sub-threshold read depth may have their genotype converted to 0/0, as specified by the `convert_gt_low_dp` input (default is `true`).
+Next, read depths of PRS variants are inspected and variants below the threshold are reported in a text output file. If no PRS variants with sub-threshold read depth exist, then no coverage check text file is outputted.
 
-After this, it checks the CNV segments file (if provided) to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. PRS variants which occur in CNVs can optionally have their genotype converted to 0/0 as specified by the `convert_gt_cnv` input (default is `true`).
+After this, it checks the CNV segments file (if provided) to see if any PRS variants are in CNVs. Details of these variants are outputted in a text file, if no such variants are present then no text file is outputted. CNV segments on ChrX are ignored as there are no X variants in the PRS list.
+
+If requested via the `convert_gt_no_call`, `convert_gt_low_dp`, or `convert_gt_cnv` inputs (default is `true`), their genotypes are converted to 0/0.
 
 Lastly, the app outputs a VCF formatted to be compatible with the [CanRisk tool](https://www.canrisk.org/canrisk_tool/).
 
@@ -21,11 +23,13 @@ Lastly, the app outputs a VCF formatted to be compatible with the [CanRisk tool]
 
 
 ## How does this app work?
-The app first identifies variants which were unable to be called via `bcftools filter` using the condition `FORMAT/GT=="./."`. If such variants are found, a .txt file containing a description of the variants (CHROM, POS, REF, ALT, DP, GT) is outputted using `bcftools isec` and `bcftools query`. If requested, the genotypes of these variants in the sample VCF are converted to 0/0 using a custom bash function `convert_gt` (see eggd_CANRISK_vcf.sh for more details).
+The app first identifies variants which were unable to be called via `bcftools filter` using the condition `FORMAT/GT=="./."`. If such variants are found, a .txt file containing a description of the variants (CHROM, POS, REF, ALT, DP, GT) is outputted using `bcftools isec` and `bcftools query`.
 
-Next, the script finds variants in the sample VCF with sub-threshold depth values using `bcftools filter` and the specified depth threshold given via the `depth` input. If requested, the app will then convert the GT values for these variants to 0/0 using the `convert_gt` function and a .txt file describing any such variants is outputted (as described above).
+Next, the script finds variants in the sample VCF with sub-threshold depth values using `bcftools filter` and the specified depth threshold given via the `depth` input.
 
-If a segments VCF is provided via the `segments_vcf` input, it checks for any CNVs that have been called via `bcftools filter` and then for any overlaps of the CNVs with PRS variants in the sample VCF using `bcftools isec`. If requested, it converts the GTs of CNV overlapping variants to 0/0 via the `convert_gt` function and a .txt file is outputted describing these variants (as described above).
+If a segments VCF is provided via the `segments_vcf` input, it checks for any CNVs that have been called via `bcftools filter` and then for any overlaps of the CNVs with PRS variants in the sample VCF using `bcftools isec`.
+
+If requested, genotypes are converted using the `convert_gt` function.
 
 ## What does this app output?
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -2,10 +2,11 @@
   "name": "eggd_canrisk_vcf",
   "title": "eggd_canrisk_vcf",
   "summary": "App to convert VCF output from sentieon Haplotyper for PRS variants to a format compatible with the CANRISK tool",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "whatsNew": {
     "v1.0.0": "Initial release of the app",
-    "v1.1.0": "Optional conversion of uncertain genotypes to 0/0, GT info added to check files and no longer output them if empty, removed exclude variants input"
+    "v1.1.0": "Optional conversion of uncertain genotypes to 0/0, GT info added to check files and no longer output them if empty, removed exclude variants input",
+    "v1.1.1": "Bugfix to handle male samples where GT is 0 (on X) instead of 0/0 (also ./. or .)"
   },
   "dxapi": "1.0.0",
   "authorizedUsers": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -6,7 +6,7 @@
   "whatsNew": {
     "v1.0.0": "Initial release of the app",
     "v1.1.0": "Optional conversion of uncertain genotypes to 0/0, GT info added to check files and no longer output them if empty, removed exclude variants input",
-    "v1.1.1": "Bugfix to handle male samples where GT is 0 (on X) instead of 0/0 (also ./. or .)"
+    "v1.1.1": "Bugfix to handle male samples (single X) by ignoring all X variants (none in PRS anyway). Improved CNV checking to verify segment overlap with PRS variants."
   },
   "dxapi": "1.0.0",
   "authorizedUsers": [

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -116,10 +116,12 @@ main() {
         # by converting CNV coordinates to a bed file
         # identify CNVs from the segments VCF (bcftools filter)
         # parse their coordinates to a bed file (bcftools query)
+        # check for overlaps between that and the sample (PRS) vcf (bcftools isec)
         bcftools filter -e 'FORMAT/GT=="0/0"' "$segments_vcf_path" | \
             bcftools query -f '%CHROM\t%POS\t%INFO/END\n' > CNV_coords.bed
+        bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | grep -v ^# > CNV_overlaps.tsv
 
-        if [ -s CNV_coords.bed ]; then
+        if [ -s CNV_overlaps.tsv ]; then
             mark-section "Writing CNV check file"
 
             # write list of affected PRS variants to output file

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -68,7 +68,7 @@ main() {
     tabix -f "$sample_vcf_path"
 
     mark-section "Checking for uncalled PRS variants"
-    bcftools filter -i 'FORMAT/GT=="./." && CHROM!="X"' "$sample_vcf_path" | \
+    bcftools filter -i 'FORMAT/GT=="./."' "$sample_vcf_path" | \
         bcftools query -f '%CHROM\t%POS\n' > uncalled_coords.tsv
 
     if [ -s uncalled_coords.tsv ]; then
@@ -84,14 +84,14 @@ main() {
 
     mark-section "Checking for low coverage"
     # identify variants with low coverage (below depth threshold input)
-    bcftools filter -i "FORMAT/DP<$depth && CHROM!='X'" "$sample_vcf_path" | \
+    bcftools filter -i "FORMAT/DP<$depth" "$sample_vcf_path" | \
         bcftools query -f '%CHROM\t%POS\n' > low_dp_coords.tsv
 
     if [ -s low_dp_coords.tsv ]; then
 
         mark-section "Writing coverage check file"
         # write list of affected PRS variants to output file
-        bcftools filter -i "FORMAT/DP<$depth && CHROM!='X'" "$sample_vcf_path" > low_cov_PRS.vcf
+        bcftools filter -i "FORMAT/DP<$depth" "$sample_vcf_path" > low_cov_PRS.vcf
         echo "The following PRS variants are not covered to $depth x read depth:" > "$sample_name"_coverage_check.txt
         echo -e "\n#CHROM\tPOS\tREF\tALT\tDP\tGT" >> "$sample_name"_coverage_check.txt
         # write relevant info about affected variants from filtered VCF
@@ -119,7 +119,7 @@ main() {
         bcftools filter -e 'FORMAT/GT=="0/0" || CHROM=="X"' "$segments_vcf_path" | \
             bcftools query -f '%CHROM\t%POS\t%INFO/END\n' > CNV_coords.bed
         if [ -s CNV_coords.bed ]; then
-        bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | bcftools view -H > CNV_overlaps.tsv
+        bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | bcftools view -H -o CNV_overlaps.tsv
         fi
 
         if [ -s CNV_overlaps.tsv ]; then

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -84,8 +84,7 @@ main() {
 
     mark-section "Checking for low coverage"
     # identify variants with low coverage (below depth threshold input)
-    filter="FORMAT/DP<$depth && CHROM!="X""
-    bcftools filter -i "$filter" "$sample_vcf_path" | \
+    bcftools filter -i 'FORMAT/DP<$depth && CHROM!="X"' "$sample_vcf_path" | \
         bcftools query -f '%CHROM\t%POS\n' > low_dp_coords.tsv
 
     if [ -s low_dp_coords.tsv ]; then

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -159,7 +159,7 @@ main() {
             echo "Genotypes of low coverage PRS variants were not converted to 0/0"
         fi
     fi
-    if [ -s CNV_coords.bed ]; then
+    if [ -s CNV_overlaps.tsv ]; then
         if $convert_gt_cnv; then
             mark-section "Converting genotype of CNV intersected PRS variants to 0/0"
             convert_gt "$sample_vcf_path" "CNV_coords.bed"

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -116,7 +116,7 @@ main() {
         # identify CNVs from the segments VCF (bcftools filter)
         # parse their coordinates to a bed file (bcftools query)
         # check for overlaps between that and the sample (PRS) vcf (bcftools isec)
-        bcftools filter -e 'FORMAT/GT=="0/0" && CHROM=="X"' "$segments_vcf_path" | \
+        bcftools filter -e 'FORMAT/GT=="0/0" || CHROM=="X"' "$segments_vcf_path" | \
             bcftools query -f '%CHROM\t%POS\t%INFO/END\n' > CNV_coords.bed
         if [ -s CNV_coords.bed ]; then
         bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | grep -v ^# > CNV_overlaps.tsv

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -119,7 +119,7 @@ main() {
         bcftools filter -e 'FORMAT/GT=="0/0" || CHROM=="X"' "$segments_vcf_path" | \
             bcftools query -f '%CHROM\t%POS\t%INFO/END\n' > CNV_coords.bed
         if [ -s CNV_coords.bed ]; then
-        bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | grep -v ^# > CNV_overlaps.tsv
+        bcftools isec "$sample_vcf_path" -T CNV_coords.bed -w1 | bcftools view -H > CNV_overlaps.tsv
         fi
 
         if [ -s CNV_overlaps.tsv ]; then

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -91,7 +91,7 @@ main() {
 
         mark-section "Writing coverage check file"
         # write list of affected PRS variants to output file
-        bcftools filter -i "$filter" "$sample_vcf_path" > low_cov_PRS.vcf
+        bcftools filter -i "FORMAT/DP<$depth && CHROM!='X'" "$sample_vcf_path" > low_cov_PRS.vcf
         echo "The following PRS variants are not covered to $depth x read depth:" > "$sample_name"_coverage_check.txt
         echo -e "\n#CHROM\tPOS\tREF\tALT\tDP\tGT" >> "$sample_name"_coverage_check.txt
         # write relevant info about affected variants from filtered VCF

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -36,7 +36,7 @@ convert_gt () {
     # check that all GTs have been converted
     gt=$(bcftools isec to_be_checked.vcf.gz -T "$regions_file" -w1 | \
         bcftools query -f '[%GT\n]' | sort | uniq)
-    if [[ "$gt" != "0/0" ]]; then
+    if [[ "$gt" != "0/0" && "$gt" != "0" ]]; then
         echo "ERROR: failed to convert GT values"
         exit 1
     fi

--- a/src/eggd_CANRISK_vcf.sh
+++ b/src/eggd_CANRISK_vcf.sh
@@ -84,7 +84,7 @@ main() {
 
     mark-section "Checking for low coverage"
     # identify variants with low coverage (below depth threshold input)
-    bcftools filter -i 'FORMAT/DP<$depth && CHROM!="X"' "$sample_vcf_path" | \
+    bcftools filter -i "FORMAT/DP<$depth && CHROM!='X'" "$sample_vcf_path" | \
         bcftools query -f '%CHROM\t%POS\n' > low_dp_coords.tsv
 
     if [ -s low_dp_coords.tsv ]; then


### PR DESCRIPTION
Added `0` to acceptable options for checking GTs have been converted (to cover single X in males)

Added extra `isec` command to allow cnv_check to only occur if segments overlap with PRS variants

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_CANRISK_vcf/20)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved genotype filtering and variant checks, particularly for CNVs.
	- Streamlined logic for genotype conversion and CNV checks.

- **Bug Fixes**
	- Addressed handling of male samples by ignoring all X variants in the context of PRS.
	- Enhanced error handling for CNV checks to ensure necessary files exist before processing.

- **Chores**
	- Incremented version number in configuration file from `1.1.0` to `1.1.1`.
	- Updated `whatsNew` section to document recent changes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->